### PR TITLE
Allow this library to be used with https://github.com/espressif/esp-cryptoauthlib (CA-88)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -72,6 +72,15 @@ config AWS_IOT_MQTT_MAX_RECONNECT_WAIT_INTERVAL
         Maximum delay between reconnection attempts. If the exponentially increased delay
         interval reaches this value, the client will stop automatically attempting to reconnect.
 
+config AWS_IOT_USE_HARDWARE_SECURE_ELEMENT
+    bool "Use hardware secure element for authenticating TLS connections"
+    depends on ATCA_MBEDTLS_ECDSA
+    help
+        If you have the fork of the Microchip cryptoauthlib (from https://github.com/espressif/esp-cryptoauthlib) for using a 
+        hardware secure element for private key storage, this will let the user specify a slot number from the
+        chip (in the format "#0" where the digit is the slot number to use) for private key storage rather 
+        than a certificate in code or a file.
+
 menu "Thing Shadow"
 
     config AWS_IOT_OVERRIDE_THING_SHADOW_RX_BUFFER

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ This framework enables AWS IoT cloud connectivity with ESP32 based platforms usi
   - ESP-IDF can be downloaded from https://github.com/espressif/esp-idf/
   - ESP-IDF v3.1 and above is recommended version
 - Please refer to [example README](examples/README.md) for more information on setting up examples
+
+## Using this library with an ATECC608a
+This port contains support for using a secure element chip from microchip.  This will store the private key used for TLS communication in the secure element.  To use this function, perform the following tasks:
+
+1. Add [esp-cryptoauthlib](https://github.com/espressif/esp-cryptoauthlib) to your project's components, and make sure it is configured
+1. Turn on AWS_IOT_USE_HARDWARE_SECURE_ELEMENT in the sdkconfig of your project.
+1. Ensure that you call `atcab_init` to initialise the microchip library before you use the AWS IoT library
+1. When connecting to AWS IoT Core, change your connection configuration to;
+  1. If you wish to use the certificate stored in the ATECC608a, set `mqttInitParams.pDeviceCertLocation = "#"`.  You may still use a certificate stored in code or on the filesystem, if you wish
+  1. Tell the IoT library to find the Private key in a slot by setting `mqttInitParams.pDevicePrivateKeyLocation = “#0”`, where the digit 0 indicates the slot in the ATECC608a that should be used to sign requests.  In most circumstances, the key will be stored in slot 0

--- a/port/network_mbedtls_wrapper.c
+++ b/port/network_mbedtls_wrapper.c
@@ -26,6 +26,12 @@
 
 #include "mbedtls/esp_debug.h"
 
+#ifdef CONFIG_AWS_IOT_USE_HARDWARE_SECURE_ELEMENT
+#include "mbedtls/atca_mbedtls_wrap.h"
+#include "tng_atca.h"
+#include "tng_atcacert_client.h"
+#endif
+
 #include "esp_log.h"
 #include "esp_vfs.h"
 
@@ -154,6 +160,20 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
     ESP_LOGD(TAG, "ok (%d skipped)", ret);
 
     /* Load client certificate... */
+#ifdef CONFIG_AWS_IOT_USE_HARDWARE_SECURE_ELEMENT
+    if (pNetwork->tlsConnectParams.pDeviceCertLocation[0] == '#') {
+        int ret;
+        const atcacert_def_t* cert_def = NULL;
+
+        ESP_LOGD(TAG, "Using certificate stored in ATECC608A");
+        ret = tng_get_device_cert_def(&cert_def);
+        if (ret == ATCACERT_E_SUCCESS) {
+            ret = atca_mbedtls_cert_add(&(tlsDataParams->clicert), cert_def);
+        } else {
+            ESP_LOGE(TAG, "Failed to load cert from ATECC608A, tng_get_device_cert_def returned %02x", ret);
+        }
+    } else 
+#endif
     if (pNetwork->tlsConnectParams.pDeviceCertLocation[0] == '/') {
         ESP_LOGD(TAG, "Loading client cert from file...");
         ret = mbedtls_x509_crt_parse_file(&(tlsDataParams->clicert),
@@ -170,6 +190,21 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
     }
 
     /* Parse client private key... */
+#ifdef CONFIG_AWS_IOT_USE_HARDWARE_SECURE_ELEMENT
+    if (pNetwork->tlsConnectParams.pDevicePrivateKeyLocation[0] == '#') {
+        int8_t slot_id = pNetwork->tlsConnectParams.pDevicePrivateKeyLocation[1] - '0';
+        if (slot_id < 0 || slot_id > 9) {
+            ESP_LOGE(TAG, "Invalid ATECC608A slot ID.");
+            ret = NETWORK_PK_PRIVATE_KEY_PARSE_ERROR;
+        } else {
+            ESP_LOGD(TAG, "Using ATECC608A private key from slot %d", slot_id);
+            ret = atca_mbedtls_pk_init(&(tlsDataParams->pkey), slot_id);
+            if (ret != 0) {
+                ESP_LOGE(TAG, " failed !  atca_mbedtls_pk_init returned %02x", ret);
+            }
+        }
+    } else 
+#endif
     if (pNetwork->tlsConnectParams.pDevicePrivateKeyLocation[0] == '/') {
         ESP_LOGD(TAG, "Loading client private key from file...");
         ret = mbedtls_pk_parse_keyfile(&(tlsDataParams->pkey),


### PR DESCRIPTION
I want to be use this library to connect to AWS, but with the private key of the client certificate stored in a secure element chip provided by Microchip.  This change adds a config variable that when set will allow the user to specify "#0" as the private key location, rather than a file or a static certificate. When it detects this, the private key will be used via the cryptoauthlib libraries.

This has been tested using an ATECC608a TNG chip