### PR TITLE
set error code to negative value of transport interface (CA-176)

### DIFF
--- a/port/network_transport/tls_freertos.c
+++ b/port/network_transport/tls_freertos.c
@@ -147,7 +147,7 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
         ( bytesToRecv == 0) ) {
         ESP_LOGE(TAG, "Invalid input parameter(s): Arguments cannot be NULL. pNetworkContext=%p, "
                 "pBuffer=%p, bytesToRecv=%d.", pNetworkContext, pBuffer, bytesToRecv );
-        return TLS_TRANSPORT_INVALID_PARAMETER;
+        return ESP_FAIL;
     }
 
     tlsStatus = esp_transport_read(pNetworkContext->transport, pBuffer, bytesToRecv, pNetworkContext->receiveTimeoutMs);
@@ -171,7 +171,7 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
         ( bytesToSend == 0) ) {
         ESP_LOGE(TAG, "Invalid input parameter(s): Arguments cannot be NULL. pNetworkContext=%p, "
                 "pBuffer=%p, bytesToSend=%d.", pNetworkContext, pBuffer, bytesToSend );
-        return TLS_TRANSPORT_INVALID_PARAMETER;
+        return ESP_FAIL;
     }
 
     tlsStatus = esp_transport_write(pNetworkContext->transport, pBuffer, bytesToSend, pNetworkContext->sendTimeoutMs);

--- a/port/network_transport/tls_freertos.h
+++ b/port/network_transport/tls_freertos.h
@@ -117,14 +117,13 @@ typedef struct NetworkCredentials
  */
 typedef enum TlsTransportStatus
 {
-    TLS_TRANSPORT_SUCCESS = 0,              /**< Function successfully completed. */
-                                            /**< -1 is reserved for ESP_FAIL */
-    TLS_TRANSPORT_INVALID_PARAMETER = -2,   /**< At least one parameter was invalid. */
-    TLS_TRANSPORT_INSUFFICIENT_MEMORY = -3, /**< Insufficient memory required to establish connection. */
-    TLS_TRANSPORT_INVALID_CREDENTIALS = -4, /**< Provided credentials were invalid. */
-    TLS_TRANSPORT_HANDSHAKE_FAILED = -5,    /**< Performing TLS handshake with server failed. */
-    TLS_TRANSPORT_INTERNAL_ERROR = -6,      /**< A call to a system API resulted in an internal error. */
-    TLS_TRANSPORT_CONNECT_FAILURE = -7      /**< Initial connection to the server failed. */
+    TLS_TRANSPORT_SUCCESS = 0,         /**< Function successfully completed. */
+    TLS_TRANSPORT_INVALID_PARAMETER,   /**< At least one parameter was invalid. */
+    TLS_TRANSPORT_INSUFFICIENT_MEMORY, /**< Insufficient memory required to establish connection. */
+    TLS_TRANSPORT_INVALID_CREDENTIALS, /**< Provided credentials were invalid. */
+    TLS_TRANSPORT_HANDSHAKE_FAILED,    /**< Performing TLS handshake with server failed. */
+    TLS_TRANSPORT_INTERNAL_ERROR,      /**< A call to a system API resulted in an internal error. */
+    TLS_TRANSPORT_CONNECT_FAILURE      /**< Initial connection to the server failed. */
 } TlsTransportStatus_t;
 
 /**

--- a/port/network_transport/tls_freertos.h
+++ b/port/network_transport/tls_freertos.h
@@ -117,13 +117,14 @@ typedef struct NetworkCredentials
  */
 typedef enum TlsTransportStatus
 {
-    TLS_TRANSPORT_SUCCESS = 0,         /**< Function successfully completed. */
-    TLS_TRANSPORT_INVALID_PARAMETER,   /**< At least one parameter was invalid. */
-    TLS_TRANSPORT_INSUFFICIENT_MEMORY, /**< Insufficient memory required to establish connection. */
-    TLS_TRANSPORT_INVALID_CREDENTIALS, /**< Provided credentials were invalid. */
-    TLS_TRANSPORT_HANDSHAKE_FAILED,    /**< Performing TLS handshake with server failed. */
-    TLS_TRANSPORT_INTERNAL_ERROR,      /**< A call to a system API resulted in an internal error. */
-    TLS_TRANSPORT_CONNECT_FAILURE      /**< Initial connection to the server failed. */
+    TLS_TRANSPORT_SUCCESS = 0,              /**< Function successfully completed. */
+                                            /**< -1 is reserved for ESP_FAIL */
+    TLS_TRANSPORT_INVALID_PARAMETER = -2,   /**< At least one parameter was invalid. */
+    TLS_TRANSPORT_INSUFFICIENT_MEMORY = -3, /**< Insufficient memory required to establish connection. */
+    TLS_TRANSPORT_INVALID_CREDENTIALS = -4, /**< Provided credentials were invalid. */
+    TLS_TRANSPORT_HANDSHAKE_FAILED = -5,    /**< Performing TLS handshake with server failed. */
+    TLS_TRANSPORT_INTERNAL_ERROR = -6,      /**< A call to a system API resulted in an internal error. */
+    TLS_TRANSPORT_CONNECT_FAILURE = -7      /**< Initial connection to the server failed. */
 } TlsTransportStatus_t;
 
 /**


### PR DESCRIPTION
 - set error code to negative value

Based on definition in [network-interface](https://www.freertos.org/network-interface.html), the return value is defined as negative  value to indicate error.
This patch set the return code of TLS_FreeRTOS_send/TLS_FreeRTOS_recv to negative value once send/recv fail.

> * @brief Transport interface for receiving data on the network.
> * ...
> * @return The number of bytes received or a **negative value to indicate error**.
> typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext, ...

> * @brief Transport interface for sending data over the network.
> * ...
> * @return The number of bytes sent or a **negative value to indicate error**.
> typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext, ...