### PR TITLE
Allow certificates in DER format (CA-245)

### DIFF
--- a/libraries/coreMQTT/port/network_transport/network_transport.c
+++ b/libraries/coreMQTT/port/network_transport/network_transport.c
@@ -10,10 +10,16 @@ TlsTransportStatus_t xTlsConnect( NetworkContext_t* pxNetworkContext )
     TlsTransportStatus_t xRet = TLS_TRANSPORT_SUCCESS;
 
     esp_tls_cfg_t xEspTlsConfig = {
-        .cacert_buf = (const unsigned char*) ( pxNetworkContext->pcServerRootCAPem ),
-        .cacert_bytes = strlen( pxNetworkContext->pcServerRootCAPem ) + 1,
-        .clientcert_buf = (const unsigned char*) ( pxNetworkContext->pcClientCertPem ),
-        .clientcert_bytes = strlen( pxNetworkContext->pcClientCertPem ) + 1,
+        .cacert_buf = pxNetworkContext->pcServerRootCADer,
+        .cacert_bytes =
+            pxNetworkContext->uxServerRootCALen == 0
+                ? strlen(pxNetworkContext->pcServerRootCAPem) + 1
+                : pxNetworkContext->uxServerRootCALen,
+        .clientcert_buf = pxNetworkContext->pcClientCertDer,
+        .clientcert_bytes =
+            pxNetworkContext->uxClientCertLen == 0
+                ? strlen(pxNetworkContext->pcClientCertPem) + 1
+                : pxNetworkContext->uxClientCertLen,
         .skip_common_name = pxNetworkContext->disableSni,
         .alpn_protos = pxNetworkContext->pAlpnProtos,
 #if CONFIG_CORE_MQTT_USE_SECURE_ELEMENT
@@ -23,8 +29,11 @@ TlsTransportStatus_t xTlsConnect( NetworkContext_t* pxNetworkContext )
 #else
         .use_secure_element = false,
         .ds_data = NULL,
-        .clientkey_buf = ( const unsigned char* )( pxNetworkContext->pcClientKeyPem ),
-        .clientkey_bytes = strlen( pxNetworkContext->pcClientKeyPem ) + 1,
+        .clientkey_buf = pxNetworkContext->pcClientKeyDer,
+        .clientkey_bytes =
+            pxNetworkContext->uxClientKeyLen == 0
+            ? strlen(pxNetworkContext->pcClientKeyPem) + 1
+            : pxNetworkContext->uxClientKeyLen,
 #endif
         .timeout_ms = 3000,
     };

--- a/libraries/coreMQTT/port/network_transport/network_transport.h
+++ b/libraries/coreMQTT/port/network_transport/network_transport.h
@@ -25,9 +25,24 @@ struct NetworkContext
     esp_tls_t* pxTls;
     const char *pcHostname;          /**< @brief Server host name. */
     int xPort;                       /**< @brief Server port in host-order. */
-    const char *pcServerRootCAPem;   /**< @brief String representing a trusted server root certificate. */
-    const char *pcClientCertPem;     /**< @brief String representing the client certificate. */
-    const char *pcClientKeyPem;      /**< @brief String representing the client certificate's private key. */
+    union
+    {
+        const char *pcServerRootCAPem;          /**< @brief A trusted server root certificate in PEM format. */
+        const unsigned char *pcServerRootCADer; /**< @brief A trusted server root certificate in DER format. */
+    };
+    size_t uxServerRootCALen;        /**< @brief The length of the trusted server root certificate or 0 if it's a null terminated PEM. */
+    union
+    {
+        const char *pcClientCertPem;            /**< @brief The client certificate in PEM format. */
+        const unsigned char *pcClientCertDer;   /**< @brief The client certificate in DER format. */
+    };
+    size_t uxClientCertLen;          /**< @brief The length of the client certificate or 0 if it's a null terminated PEM. */
+    union
+    {
+        const char *pcClientKeyPem;             /**< @brief The client certificate's private key in PEM format. */
+        const unsigned char *pcClientKeyDer;    /**< @brief The client certificate's private key in DER format. */
+    };
+    size_t uxClientKeyLen;           /**< @brief The length of the client certificate's private key or 0 if it's a null terminated PEM. */
     bool use_secure_element;         /**< @brief Boolean representing the use of secure element
                                                  for the TLS connection. */
     void *ds_data;                   /**< @brief Pointer for digital signature peripheral context */


### PR DESCRIPTION
This PR allows binary (DER) certificates to be passed through AWS IoT to `esp_tls_cfg_t`, which already supports them.