### PR TITLE
Don't use EXAMPLE defines to disable functionality

### DIFF
--- a/libraries/coreHTTP/port/network_transport/network_transport.c
+++ b/libraries/coreHTTP/port/network_transport/network_transport.c
@@ -16,16 +16,10 @@ TlsTransportStatus_t xTlsConnect( NetworkContext_t* pxNetworkContext )
         .clientcert_bytes = strlen( pxNetworkContext->pcClientCertPem ) + 1,
         .skip_common_name = pxNetworkContext->disableSni,
         .alpn_protos = pxNetworkContext->pAlpnProtos,
-#if CONFIG_CORE_HTTP_USE_SECURE_ELEMENT
-        .use_secure_element = true,
-#elif CONFIG_CORE_HTTP_USE_DS_PERIPHERAL
+        .use_secure_element = pxNetworkContext->use_secure_element,
         .ds_data = pxNetworkContext->ds_data,
-#else
-        .use_secure_element = false,
-        .ds_data = NULL,
         .clientkey_buf = ( const unsigned char* )( pxNetworkContext->pcClientKeyPem ),
-        .clientkey_bytes = strlen( pxNetworkContext->pcClientKeyPem ) + 1,
-#endif
+        .clientkey_bytes = pxNetworkContext->pcClientKeyPem == NULL ? 0 : strlen( pxNetworkContext->pcClientKeyPem ) + 1,
         .timeout_ms = 3000,
     };
 

--- a/libraries/coreMQTT/port/network_transport/network_transport.c
+++ b/libraries/coreMQTT/port/network_transport/network_transport.c
@@ -16,16 +16,10 @@ TlsTransportStatus_t xTlsConnect( NetworkContext_t* pxNetworkContext )
         .clientcert_bytes = strlen( pxNetworkContext->pcClientCertPem ) + 1,
         .skip_common_name = pxNetworkContext->disableSni,
         .alpn_protos = pxNetworkContext->pAlpnProtos,
-#if CONFIG_CORE_MQTT_USE_SECURE_ELEMENT
-        .use_secure_element = true,
-#elif CONFIG_CORE_MQTT_USE_DS_PERIPHERAL
+        .use_secure_element = pxNetworkContext->use_secure_element,
         .ds_data = pxNetworkContext->ds_data,
-#else
-        .use_secure_element = false,
-        .ds_data = NULL,
         .clientkey_buf = ( const unsigned char* )( pxNetworkContext->pcClientKeyPem ),
-        .clientkey_bytes = strlen( pxNetworkContext->pcClientKeyPem ) + 1,
-#endif
+        .clientkey_bytes = pxNetworkContext->pcClientKeyPem == NULL ? 0 : strlen( pxNetworkContext->pcClientKeyPem ) + 1,
         .timeout_ms = 3000,
     };
 


### PR DESCRIPTION
This is a library so should be usable outside the context of the examples. The examples already set the members of `NetworkContext_t` correctly using the defines so they don't need to be checked again here while copying to `esp_tls_cfg_t`.