### PR TITLE
Fix Jobs example. (CA-262)

### DIFF
--- a/examples/jobs/main/mqtt_demo_helpers.c
+++ b/examples/jobs/main/mqtt_demo_helpers.c
@@ -1068,3 +1068,14 @@ int32_t PublishToTopic( const char * pTopicFilter,
     return returnStatus;
 }
 /*-----------------------------------------------------------*/
+
+MQTTStatus_t processLoop( void )
+{
+    MQTTStatus_t eMqttStatus;
+
+    eMqttStatus = MQTT_ProcessLoop( &mqttContext );
+    
+    return eMqttStatus;
+}
+
+/*-----------------------------------------------------------*/

--- a/examples/jobs/main/mqtt_demo_helpers.h
+++ b/examples/jobs/main/mqtt_demo_helpers.h
@@ -118,4 +118,10 @@ int32_t PublishToTopic( const char * pTopicFilter,
  */
 MQTTStatus_t processLoopWithTimeout( uint32_t ulTimeoutMs );
 
+/**
+ * @brief Call #MQTT_ProcessLoop on the static global MQTT context.
+ * @return Returns the return value #MQTT_ProcessLoop.
+ */
+MQTTStatus_t processLoop( void );
+
 #endif /* ifndef SHADOW_DEMO_HELPERS_H_ */


### PR DESCRIPTION
This PR fixes:
* An infinite recursion that can occur when receiving a jobs message while in the middle of processing another one by offloading handling job messages from the coreMQTT event callback to the main demo task.
* Fixes incorrect logic for checking errors on unsubscribe.
* Fixes the demo retry logic.
* Fixes printing a warning when a timestamp message is received.

This code was tested using an ESP32-S2 on ESP-IDF v5.0.