### PR TITLE
TLS Mutual Auth Example Fix

### DIFF
--- a/examples/mqtt/tls_mutual_auth/main/mqtt_demo_mutual_auth.c
+++ b/examples/mqtt/tls_mutual_auth/main/mqtt_demo_mutual_auth.c
@@ -750,7 +750,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
             }
         }
 
-        if( returnStatus == EXIT_FAILURE )
+        if( returnStatus == EXIT_FAILURE || tlsStatus == TLS_TRANSPORT_CONNECT_FAILURE )
         {
             /* Generate a random number and get back-off value (in milliseconds) for the next connection retry. */
             backoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &reconnectParams, generateRandomNumber(), &nextRetryBackOff );


### PR DESCRIPTION
 Fixed edge case where if TLS connection failed it would return as a successful connection to the MQTT broker.