### PR TITLE
Add GRI_TRANSPORT_TIMEOUT_MS to improve TLS connection reliability (CA-301)

### DIFF
--- a/libraries/coreMQTT/port/network_transport/network_transport.h
+++ b/libraries/coreMQTT/port/network_transport/network_transport.h
@@ -55,6 +55,7 @@ struct NetworkContext
     * @brief Disable server name indication (SNI) for a TLS session.
     */
     BaseType_t disableSni;
+    TickType_t xTimeout;
 };
 
 TlsTransportStatus_t xTlsConnect(NetworkContext_t* pxNetworkContext );

--- a/libraries/coreMQTT/port/network_transport/network_transport.h
+++ b/libraries/coreMQTT/port/network_transport/network_transport.h
@@ -12,6 +12,10 @@
 #include "transport_interface.h"
 #include "esp_tls.h"
 
+#if !defined( CONFIG_GRI_TRANSPORT_TIMEOUT_MS )
+    #define CONFIG_GRI_TRANSPORT_TIMEOUT_MS    1000
+#endif /* TLS_TRANSPORT_TIMEOUT_MS */
+
 typedef enum TlsTransportStatus
 {
     TLS_TRANSPORT_SUCCESS = 0,              /**< Function successfully completed. */
@@ -55,10 +59,9 @@ struct NetworkContext
     * @brief Disable server name indication (SNI) for a TLS session.
     */
     BaseType_t disableSni;
-    TickType_t xTimeout;
 };
 
-TlsTransportStatus_t xTlsConnect(NetworkContext_t* pxNetworkContext );
+TlsTransportStatus_t xTlsConnect( NetworkContext_t* pxNetworkContext );
 
 TlsTransportStatus_t xTlsDisconnect( NetworkContext_t* pxNetworkContext );
 


### PR DESCRIPTION
Makes the TLS connection more reliable by avoiding the `timeout_ms` limitation that traded performance for reliability when it was increased.