### PR TITLE
Fix transport recv return value (CA-343)

### DIFF
--- a/libraries/coreMQTT/port/network_transport/network_transport.c
+++ b/libraries/coreMQTT/port/network_transport/network_transport.c
@@ -202,7 +202,7 @@ int32_t espTlsTransportSend( NetworkContext_t* pxNetworkContext,
 int32_t espTlsTransportRecv( NetworkContext_t* pxNetworkContext,
                              void* pvData, size_t uxDataLen )
 {
-    int32_t lBytesRead = 0;
+    int32_t lBytesRead = -1;
 
     if( ( pvData != NULL ) &&
         ( uxDataLen > 0 ) &&
@@ -221,6 +221,8 @@ int32_t espTlsTransportRecv( NetworkContext_t* pxNetworkContext,
             int lSockFd = -1;
             fd_set read_fds;
             fd_set error_fds;
+
+            lBytesRead = 0;
 
             esp_tls_get_conn_sockfd( pxNetworkContext->pxTls, &lSockFd );
             FD_ZERO( &read_fds );


### PR DESCRIPTION
**In this PR:**
* Transport interface recv function returns 0 should represent the read operation can be retried. Negative value should be returned when input parameters and recv bytes are invalid. Reference this [document](https://freertos.github.io/coreMQTT/latest/group__mqtt__callback__types.html#ga227df31d6daf07e5d833537c12130167).

**Test**
Run the [transport interface test](https://github.com/FreeRTOS/FreeRTOS-Libraries-Integration-Tests/tree/main/src/transport_interface) the following test cases should has no error.
```
TEST(Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:865::FAIL: Expected 0 to be less than 0. Transport interface recv with NULL network context pointer should return negative value.

TEST(Full_TransportInterfaceTest, TransportRecv_BufferNullPtr)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:886::FAIL: Expected 0 to be less than 0. Transport interface recv with NULL buffer pointer should return negative value.

TEST(Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:905::FAIL: Expected 0 to be less than 0. Transport interface recv with zero byte to recv should return negative value.
```