### PR TITLE
Initial return value of connectToServerWithBackoffRetries in the tls_mutual_auth example is set incorrectly (CA-358)

### DIFF
--- a/examples/mqtt/tls_mutual_auth/main/mqtt_demo_mutual_auth.c
+++ b/examples/mqtt/tls_mutual_auth/main/mqtt_demo_mutual_auth.c
@@ -630,7 +630,7 @@ static int connectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext
                                               bool * pClientSessionPresent,
                                               bool * pBrokerSessionPresent )
 {
-    int returnStatus = EXIT_SUCCESS;
+    int returnStatus = EXIT_FAILURE;
     BackoffAlgorithmStatus_t backoffAlgStatus = BackoffAlgorithmSuccess;
     TlsTransportStatus_t tlsStatus = TLS_TRANSPORT_SUCCESS;
     BackoffAlgorithmContext_t reconnectParams;


### PR DESCRIPTION
## Description
The function `connectToServerWithBackoffRetries` in the file `mqtt_demo_mutual_auth.c` has its initial return status incorrectly set to `EXIT_SUCCESS`. In situations where the tls connection fails, the program continues as if it was successful, returning `EXIT_SUCCESS`. In order for the back off retries to function, this must be set to `EXIT_FAILURE`.

## Testing
Tested with esp-idf version `ESP-IDF v5.2.5-30-g41c2b799ad`
I can see the example message on the aws IoT test client.

Without this change, turning off the wifi access point during the demo doesn't trigger the backoff retries when trying to connect. With this change, the increasing times between retries can be seen in the console.