### PR TITLE
feat: implement otaPal function for resuming ota from specified byte

### DIFF
--- a/libraries/aws-iot-core-mqtt-file-streams-embedded-c/port/ota_pal.c
+++ b/libraries/aws-iot-core-mqtt-file-streams-embedded-c/port/ota_pal.c
@@ -231,6 +231,45 @@ OtaPalStatus_t otaPal_CreateFileForRx( AfrOtaJobDocumentFields_t * const pFileCo
     return OtaPalSuccess;
 }
 
+OtaPalStatus_t otaPal_ResumeFileForRx( AfrOtaJobDocumentFields_t * const pFileContext,
+                                       uint32_t ulStartOffset )
+{
+    if( ( pFileContext == NULL ) || ( pFileContext->filepath == NULL ) )
+    {
+        return OtaPalRxFileResumeFailed;
+    }
+
+    const esp_partition_t * update_partition = esp_ota_get_next_update_partition( NULL );
+
+    if( update_partition == NULL )
+    {
+        LogError( ( "Failed to find update partition for resume" ) );
+        return OtaPalRxFileResumeFailed;
+    }
+
+    esp_ota_handle_t update_handle;
+    esp_err_t err = esp_ota_resume( update_partition,
+                                    OTA_SIZE_UNKNOWN,
+                                    ulStartOffset,
+                                    &update_handle );
+
+    if( err != ESP_OK )
+    {
+        LogError( ( "esp_ota_resume failed (%d)", err ) );
+        return OtaPalRxFileResumeFailed;
+    }
+
+    ota_ctx.cur_ota = pFileContext;
+    ota_ctx.update_partition = update_partition;
+    ota_ctx.update_handle = update_handle;
+    ota_ctx.data_write_len = ulStartOffset;
+    ota_ctx.valid_image = false;
+
+    LogInfo( ( "esp_ota_resume succeeded at offset %" PRIu32 "",
+               ulStartOffset ) );
+
+    return OtaPalSuccess;
+}
 
 /* Verify the signature of the specified file. */
 OtaPalStatus_t otaPal_CheckFileSignature( AfrOtaJobDocumentFields_t * const pFileContext )

--- a/libraries/aws-iot-core-mqtt-file-streams-embedded-c/port/ota_pal.h
+++ b/libraries/aws-iot-core-mqtt-file-streams-embedded-c/port/ota_pal.h
@@ -65,6 +65,7 @@ typedef uint32_t OtaPalStatus_t;
 #define    OtaPalActivateFailed            0xecU /*!< @brief The activation of the new OTA image failed. */
 #define    OtaPalFileAbort                 0xedU /*!< @brief Error in low level file abort. */
 #define    OtaPalFileClose                 0xeeU /*!< @brief Error in low level file close. */
+#define    OtaPalRxFileResumeFailed        0xefU /*!< @brief The PAL failed to resume the OTA receive file. */
 
 #define OTA_FILE_SIG_KEY_STR_MAX_LENGTH    32    /*!< Maximum length of the file signature key. */
 
@@ -190,6 +191,30 @@ OtaPalStatus_t otaPal_Abort( AfrOtaJobDocumentFields_t * const pFileContext );
  * OtaPalRxFileCreateFailed is returned for other errors creating the file in the device's non-volatile memory.
  */
 OtaPalStatus_t otaPal_CreateFileForRx( AfrOtaJobDocumentFields_t * const pFileContext );
+
+/**
+ * @brief Resume an OTA receive file from a previously written byte offset.
+ *
+ * @note Opens the update partition context for an already-started image download and
+ * positions writes to continue at ulStartOffset bytes.
+ *
+ * @note The input OtaFileContext_t pFileContext is checked for NULL by the OTA agent
+ * before this function is called.
+ * The device file path is a required field in the OTA job document, so
+ * pFileContext->pFilePath is checked for NULL by the OTA agent before this function
+ * is called.
+ *
+ * @param[in] pFileContext OTA file context information.
+ * @param[in] ulStartOffset Number of bytes already written to the update image.
+ *
+ * @return The OTA PAL layer error code combined with the MCU specific error code.
+ * See OTA Agent error codes information in ota.h.
+ *
+ * OtaPalSuccess is returned when OTA resume context initialization is successful.
+ * OtaPalRxFileResumeFailed is returned for errors resuming the OTA receive context.
+ */
+OtaPalStatus_t otaPal_ResumeFileForRx( AfrOtaJobDocumentFields_t * const pFileContext,
+                                       uint32_t ulStartOffset );
 
 /**
  * @brief Authenticate and close the underlying receive file in the specified OTA context.


### PR DESCRIPTION
## Description

This PR introduces OTA resume support in PAL and updates related interface behavior/documentation.

Summary of changes:
- Added `otaPal_ResumeFileForRx()` API to resume OTA write session from a previously written offset.
- Implemented resume flow in PAL using `esp_ota_resume(...)` and restoring PAL OTA context (`partition`, `handle`, `written length`, and image validity state).
- Extended PAL header docs for resume API in the same style as other OTA PAL methods (notes, preconditions, and explicit return semantics).
- Added resume-specific PAL error code (`OtaPalRxFileResumeFailed`) and used it in resume failure branches for clearer diagnostics.

Motivation:
- Support interruption-tolerant OTA by allowing download continuation from checkpointed byte offset.
- Reduce full-download restarts after reconnect/reboot and improve OTA robustness.
- Keep PAL API contract explicit and consistent for integrators.

Scope:
- OTA PAL only (interface + implementation for resume path and docs).
- Existing create/write/close OTA paths remain unchanged.

## Related

- OTA restart/resume hardening workstream.
- No external issue linked.

## Testing

Manual/verification steps:
- Verified resume API is declared in PAL header and documented with full contract.
- Verified resume API implementation initializes OTA context from `ulStartOffset` and uses `esp_ota_resume(...)`.
- Verified resume failure branches return `OtaPalRxFileResumeFailed`.

Runtime validation plan:
- Start OTA, interrupt transfer mid-way, reboot/reconnect, and continue OTA from saved checkpoint.
- Verify final image passes signature check and activation succeeds after resumed transfer.
- Negative test: provide invalid resume conditions (offset/context mismatch) and verify resume path fails fast with resume-specific PAL status.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.