### PR TITLE
fix(coreHTTP): rename colliding DEVICE_SHADOW_LOG_* Kconfig symbols (CA-367)

### DIFF
--- a/libraries/coreHTTP/Kconfig
+++ b/libraries/coreHTTP/Kconfig
@@ -2,19 +2,19 @@ menu "coreHTTP"
 
     menu "Logging"
 
-        config DEVICE_SHADOW_LOG_ERROR
+        config CORE_HTTP_LOG_ERROR
             bool "Enable Error Logging"
             default y
-        
-        config DEVICE_SHADOW_LOG_WARN
+
+        config CORE_HTTP_LOG_WARN
             bool "Enable Warning Logging"
             default n
 
-        config DEVICE_SHADOW_LOG_INFO
+        config CORE_HTTP_LOG_INFO
             bool "Enable Info Logging"
             default y
 
-        config DEVICE_SHADOW_LOG_DEBUG
+        config CORE_HTTP_LOG_DEBUG
             bool "Enable Debug Logging"
             default n
 


### PR DESCRIPTION
## Summary
- Renames `DEVICE_SHADOW_LOG_*` symbols in `libraries/coreHTTP/Kconfig` to `CORE_HTTP_LOG_*`, matching the naming used by other libraries (e.g. `CORE_MQTT_LOG_*`).
- Fixes the Kconfig symbol collision reported in #251 when both coreHTTP and Device Shadow are included in a project.

## Context
Issue #251 identified a copy-paste error where coreHTTP defined Device Shadow logging symbols. A maintainer suggested the exact `CORE_HTTP_LOG_*` rename applied here.

## Test plan
- [ ] Include both `libraries/coreHTTP` and `libraries/Device-Shadow-for-AWS-IoT-embedded-sdk` in an ESP-IDF project
- [ ] Run `idf.py reconfigure` (or `idf.py build`)
- [ ] Confirm there are no `DEVICE_SHADOW_LOG_* defined in multiple locations` warnings
- [ ] Confirm menuconfig shows coreHTTP logging options as `CORE_HTTP_LOG_*`


Made with [Cursor](https://cursor.com)