### PR TITLE
fix(coreMQTT): null pxTls after xTlsDisconnect (CA-365)

### DIFF
--- a/libraries/coreMQTT/port/network_transport/network_transport.c
+++ b/libraries/coreMQTT/port/network_transport/network_transport.c
@@ -108,6 +108,9 @@ TlsTransportStatus_t xTlsDisconnect( NetworkContext_t* pxNetworkContext )
             xResult = TLS_TRANSPORT_DISCONNECT_FAILURE;
         }
 
+        /* Destroy frees the TLS object; clear to avoid a dangling pointer. */
+        pxNetworkContext->pxTls = NULL;
+
         ( void ) xSemaphoreGive( pxNetworkContext->xTlsContextSemaphore );
     }
     else


### PR DESCRIPTION
## Summary
- Clears `pxNetworkContext->pxTls` after `esp_tls_conn_destroy` in `xTlsDisconnect`.
- Prevents use-after-free / double-free when disconnect, send, or recv runs again on the same `NetworkContext_t`.
- Aligns coreMQTT transport with the existing coreHTTP transport behavior.

Fixes #249

## Context
`esp_tls_conn_destroy` frees the TLS object, but assigning `tls = NULL` inside that API has no effect on the caller's pointer (passed by value). Callers must clear their own handle. coreHTTP already does this; coreMQTT did not.

## Test plan
- [ ] Connect with `xTlsConnect`, then disconnect with `xTlsDisconnect`
- [ ] Confirm `networkContext.pxTls == NULL` after disconnect
- [ ] Call `xTlsDisconnect` a second time and confirm it returns success without asserting / double-free
- [ ] Confirm `espTlsTransportSend` / `espTlsTransportRecv` after disconnect return failure instead of crashing


Made with [Cursor](https://cursor.com)